### PR TITLE
Update repo name to `frontends-team-compass`

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A repository for team interaction, syncing, and handling meeting notes across the JupyterLab ecosystem.
 
-## Weekly JupyterLab team meeting
+## Weekly Jupyter Frontends team meeting
 Weekly team meetings take place on the [Jupyter Zoom room](https://zoom.us/my/jovyan?pwd=c0JZTHlNdS9Sek9vdzR3aTJ4SzFTQT09) on Wednesdays at 9:00 AM Pacific Time ([your time](https://www.thetimezoneconverter.com/?t=9%3A00%20am&tz=San%20Francisco)). Minutes will be taken at [Hackmd.io](https://hackmd.io/Y7fBMQPSQ1C08SDGI-fwtg). Each meeting's minutes will be added as a comment to an issue in this project.
 
 ## Weekly Jupyter triage meeting

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,8 +45,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Team Compass'
-copyright = '2024, JupyterLab'
-author = 'JupyterLab Team'
+copyright = '2024, Jupyter Frontends'
+author = 'Jupyter Frontends Team'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -150,7 +150,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'TeamCompass.tex', 'Team Compass Documentation',
-     'JupyterLab Team', 'manual'),
+     'Jupyter Frontends Team', 'manual'),
 ]
 
 

--- a/docs/host-guide.md
+++ b/docs/host-guide.md
@@ -81,7 +81,7 @@ connection, a good quality microphone, and a quiet environment.
 
 - Weekly Meeting Notes: https://hackmd.io/Y7fBMQPSQ1C08SDGI-fwtg
 - Jupyter Code of Conduct: https://jupyter.org/governance/conduct/code_of_conduct.html
-- JupyterLab Team Compass: https://github.com/jupyterlab/team-compass
+- Jupyter Frontends Team Compass: https://github.com/jupyterlab/frontends-team-compass
 
 ### &#x1F399; At the start of the meeting
 
@@ -101,7 +101,7 @@ posted to YouTube for the community to view. Please keep that in mind while
 you’re here.
 
 Second, I’d like to remind people that as this is a part of the Jupyter
-community we are all held to the Jupyter Code of Conduct. You can read about 
+community we are all held to the Jupyter Code of Conduct. You can read about
 the code of conduct at jupyter.org/conduct.
 
 If you haven’t been here before, here’s how this works. Presenters have
@@ -134,7 +134,7 @@ If you have any feedback, please direct it at [platform/link]. I’d love to hea
 you think about the call.
 
 Our next community call will be [day, month]. Check out the Jupyter community calendar
-to see what other types of meetings 
+to see what other types of meetings
 are happening in between.
 
 If you have any interest in sharing in future community calls, please do! It doesn’t
@@ -154,7 +154,7 @@ There are just a few post-meeting TODO items:
 - [ ] Finalize meeting minutes: Go back to HackMD and make any needed additions,
 corrections and formatting you can.
 - [ ] Publish the minutes: Convert the HackMD document to markdown and publish
-it to the relevant Weekly Team Meetings archive issue on GitHub [(example)](https://github.com/jupyterlab/team-compass/issues/205)
+it to the relevant Weekly Team Meetings archive issue on GitHub [(example)](https://github.com/jupyterlab/frontends-team-compass/issues/205)
 in the JupyterLab team-compass repository for the corresponding time period
 (search issues, and look for the 6 month period the meeting belongs to).
 

--- a/docs/host-guide.md
+++ b/docs/host-guide.md
@@ -10,7 +10,7 @@ peruse the other sections for basic info and additional context.
 
 ## &#x23F0; Basic Meeting Event Info
 
-JupyterLab team meetings are held every Wednesday. You can check the [Jupyter Community Meetings calendar](https://jupyter.org/community#calendar) for the exact time in your timezone.
+Jupyter Frontends team meetings are held every Wednesday. You can check the [Jupyter Community Meetings calendar](https://jupyter.org/community#calendar) for the exact time in your timezone.
 
 Read the [weekly meeting notes/agenda here](https://hackmd.io/Y7fBMQPSQ1C08SDGI-fwtg).
 
@@ -155,7 +155,7 @@ There are just a few post-meeting TODO items:
 corrections and formatting you can.
 - [ ] Publish the minutes: Convert the HackMD document to markdown and publish
 it to the relevant Weekly Team Meetings archive issue on GitHub [(example)](https://github.com/jupyterlab/frontends-team-compass/issues/205)
-in the JupyterLab team-compass repository for the corresponding time period
+in the Jupyter Frontends team-compass repository for the corresponding time period
 (search issues, and look for the 6 month period the meeting belongs to).
 
 &#x1F305; The Jupyter community depends on volunteers like you, so again we

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,7 +6,7 @@ JupyterLab Team Compass
 This page contains links to the notes from team meetings
 with the JupyterLab community. For more some more technical information
 and links to various JupyterLab repositories, see the
-`Team Compass README <https://github.com/jupyterlab/team-compass>`_.
+`Team Compass README <https://github.com/jupyterlab/frontends-team-compass>`_.
 
 Team Compass Resources
 ======================

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,6 +1,6 @@
-=======================
-JupyterLab Team Compass
-=======================
+==============================
+Jupyter Frontends Team Compass
+==============================
 
 
 This page contains links to the notes from team meetings
@@ -27,7 +27,7 @@ governance and planning.
 Why have a Team Compass?
 ========================
 
-This repository helps the JupyterLab team set a weekly
+This repository helps the Jupyter Frontends team set a weekly
 course for project activity. Our overriding goal is continuous team and
 project improvement.
 

--- a/docs/team/member-guide.md
+++ b/docs/team/member-guide.md
@@ -10,11 +10,11 @@ They're meant to guide members to be happy, productive members of the team!
 There are a few resources that are particularly useful for team members. Here's
 a quick list to get you started.
 
-* [**The Jupyter Frontends Team Compass**](https://github.com/jupyterlab/team-compass)
+* [**The Jupyter Frontends Team Compass**](https://github.com/jupyterlab/frontends-team-compass)
   is a repository with lots of information about team-related things. It has
   development tips, information about team meetings, milestones and roadmaps,
   etc.
-* [**The Jupyter Frontends Team Compass issues**](https://github.com/jupyterlab/team-compass/issues)
+* [**The Jupyter Frontends Team Compass issues**](https://github.com/jupyterlab/frontends-team-compass/issues)
   are where we often discuss specific, actionable things related to the *team*
   (e.g., discussing whether to change something in the team-compass repo).
 
@@ -48,10 +48,10 @@ We don't want team membership to
 be a big burden (many of us have one or more other jobs too!) but there are
 a few things that you should do as a new member:
 
-1. **"Watch" the [team compass repository](https://github.com/jupyterlab/team-compass)** and the [council repository](https://github.com/jupyterlab/council)
+1. **"Watch" the [team compass repository](https://github.com/jupyterlab/frontends-team-compass)** and the [council repository](https://github.com/jupyterlab/council)
    so that you're notified when team conversations are happening.
 2. **Stay up-to-date on team meetings**. You can find a notes from previous meetings pinned at
-   the [top of the team-compass issues page](https://github.com/jupyterlab/team-compass/issues).
+   the [top of the team-compass issues page](https://github.com/jupyterlab/frontends-team-compass/issues).
 3. **Vote**. Participate in at least 2/3 of votes happening in the team-compass repo. You should be automatically pinged on Github when a vote is called.
 4. **Let us know if you'll be unavailable** or out of town for an extended period
    of time. It's no problem if you need to focus on other things for a bit, but it's


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/frontends-team-compass/issues/242

- [x] Update references to the repo to https://github.com/jupyterlab/frontends-team-compass
- [x] Rename the repo