### PR TITLE
Update my affiliation

### DIFF
--- a/docs/team/contributors.yaml
+++ b/docs/team/contributors.yaml
@@ -87,7 +87,7 @@
 
 - name: Michał Krassowski
   handle: "@krassowski"
-  affiliation: Quansight
+  affiliation: OpenTeams
   last-check-in: "Thu 05 Dec 2024"
 
 - name: Martha Cryan


### PR DESCRIPTION
Quansight → OpenTeams.

Since this will involve many folks you know in the community updating their affiliations over the coming days, for anyone curious:
- Quansight Labs LLC → Quansight PBC (Public Benefit Corporation): [LinkedIn post](https://www.linkedin.com/posts/quansight_opensource-community-publicbenefit-activity-7333164995570040832-Z-KU/), [press release](https://www.businesswire.com/news/home/20250527890413/en/Quansight-Transitions-to-a-Public-Benefit-Corporation-PBC-Reinforcing-Commitment-to-Sustainable-Open-Source-Software) 
- Quansight Consulting → OpenTemas: [LinkedIn post](https://www.linkedin.com/posts/openteams_ownyourai-opensourceai-aiforenterprise-activity-7333164659841171457-M6H3/), [press release](https://www.businesswire.com/news/home/20250527258356/en/OpenTeams-Acquires-Quansights-AI-Consulting-Division-to-Accelerate-Open-Source-AI-for-Enterprise-and-Government)