### PR TITLE
Add workflow to run Yuvi's pr triage bot

### DIFF
--- a/.github/workflows/pr-triage-bot.yml
+++ b/.github/workflows/pr-triage-bot.yml
@@ -1,0 +1,18 @@
+name: PR Triage Board Bot
+
+on:
+  schedule:
+    # Run every hour
+    - cron: '0 * * * *'
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  jupyterlab:
+    uses: yuvipanda/pr-triage-board-bot/.github/workflows/reusable-pr-triage.yml@main
+    with:
+      organization: 'jupyterlab'
+      project-number: '11'
+      gh-app-id: '1842581'
+      gh-installation-id: '82755492'
+    secrets:
+      gh-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY_JUPYTERLAB }}


### PR DESCRIPTION
See https://github.com/yuvipanda/pr-triage-board-bot. This replaces our hardcoded running of the workflow in https://github.com/yuvipanda/pr-triage-board-bot/blob/f316658cd850a8cd0bd4cc06cfe06adc873124a8/.github/workflows/run.yaml#L22-L30